### PR TITLE
Add the TFS user information to the checkin message for each Git...

### DIFF
--- a/src/OneWayMirror.Core/OneWayMirrorUtil.cs
+++ b/src/OneWayMirror.Core/OneWayMirrorUtil.cs
@@ -38,6 +38,7 @@ namespace OneWayMirror.Core
                 host,
                 tfsWorkspace,
                 workspacePath,
+                tfsWorkspacePath,
                 gitRepository,
                 gitRepositoryUrl,
                 gitRemoteName,


### PR DESCRIPTION
... -> TFS port. It basically has: ‘<TFS-User-Name> (<MS-email ID>)’ for the GitHub commiter.

Example:
Checked in on behalf of: 'Manish Vasani (mavasani@microsoft.com)'

@jaredpar can you please take a look?
