### PR TITLE
Include the Git branch when reporting program failures.

### DIFF
--- a/src/OneWayMirror/Program.cs
+++ b/src/OneWayMirror/Program.cs
@@ -30,7 +30,7 @@ namespace OneWayMirror
             var tfsUserInfoMappingFilePath = Path.Combine(tfsWorkspacePath, tfsUserInfoMappingFileRelativePath);
 
             OneWayMirrorUtil.Run(
-                new ReportingConsoleHost(verbose: true, reportEmailAddress: alertEmailAddress),
+                new ReportingConsoleHost(verbose: true, reportEmailAddress: alertEmailAddress, gitRemoteName: gitRemoteName, gitBranchName: gitBranchName),
                 tfsCollection,
                 tfsWorkspacePath,
                 tfsTargetPath,

--- a/src/OneWayMirror/ReportingConsoleHost.cs
+++ b/src/OneWayMirror/ReportingConsoleHost.cs
@@ -11,10 +11,14 @@ namespace OneWayMirror
     internal sealed class ReportingConsoleHost : ConsoleHost
     {
         private readonly string _reportEmailAddress;
+        private readonly string _gitRemoteName;
+        private readonly string _gitBranchName;
 
-        internal ReportingConsoleHost(bool verbose, string reportEmailAddress) : base(verbose)
+        internal ReportingConsoleHost(bool verbose, string reportEmailAddress, string gitRemoteName, string gitBranchName) : base(verbose)
         {
             _reportEmailAddress = reportEmailAddress;
+            _gitRemoteName = gitRemoteName;
+            _gitBranchName = gitBranchName;
         }
 
         private void SendMail(string body)
@@ -24,7 +28,7 @@ namespace OneWayMirror
                 msg.To.Add(new MailAddress(_reportEmailAddress));
                 msg.From = new MailAddress(Environment.UserName + @"@microsoft.com");
                 msg.IsBodyHtml = false;
-                msg.Subject = "Git to TFS Mirror Error";
+                msg.Subject = string.Format("Git to TFS Mirror Error ({0}/{1})", _gitRemoteName, _gitBranchName);
                 msg.Body = body;
 
                 var client = new SmtpClient("smtphost");


### PR DESCRIPTION
This modifies `ReportingConsoleHost` to include the Git branch when
reporting a program failure.
